### PR TITLE
Buttonlösung - Wording

### DIFF
--- a/src/app/locale/de_DE/template/germansetup/page/bestellung.html
+++ b/src/app/locale/de_DE/template/germansetup/page/bestellung.html
@@ -28,7 +28,7 @@ Richtigkeit und Vollständigkeit dieser Texte eine Verantwortung.</p>
 
 <h4>5. Bestellvorgang abschließen / AGB und Datenschutz</h4>
 
-<p>Sie erhalten eine Übersicht Ihrer Bestellung: die ausgewählten Produkte, die Versand- und Rechnungsadresse und Ihre Kontaktdaten. Überprüfen Sie, ob alle Angaben stimmen und lesen sich bitte die <a href="{{store url="agb"}}">Allgemeinen Geschäftsbedingungen</a> und die <a href="{{store url="widerruf"}}">Widerrufsbelehrung</a> aufmerksam durch. Sie können mit der Bestellung nur fortfahren, wenn Sie den AGB und der Widerrufsbelehrung zustimmen (Häkchen setzen). Mit dem Anklicken des Buttons "Bestellung absenden" übersenden Sie Ihre Bestellung an uns. Hiermit geben Sie ein rechtsverbindliches Angebot ab.</p>
+<p>Sie erhalten eine Übersicht Ihrer Bestellung: die ausgewählten Produkte, die Versand- und Rechnungsadresse und Ihre Kontaktdaten. Überprüfen Sie, ob alle Angaben stimmen und lesen sich bitte die <a href="{{store url="agb"}}">Allgemeinen Geschäftsbedingungen</a> und die <a href="{{store url="widerruf"}}">Widerrufsbelehrung</a> aufmerksam durch. Sie können mit der Bestellung nur fortfahren, wenn Sie den AGB und der Widerrufsbelehrung zustimmen (Häkchen setzen). Mit dem Anklicken des Buttons "Jetzt kaufen" übersenden Sie Ihre Bestellung an uns. Hiermit geben Sie ein rechtsverbindliches Angebot ab.</p>
 
 <h4>Widerrufsrecht für Verbraucher</h4>
 


### PR DESCRIPTION
Ändert die Referenz im Text der Buttonbezeichnung des Warenkorbs von "Bestellung senden" zu "Jetzt kaufen".

Änderung wird mit dem 1.7.x de_DE ausgerollt.
