### PR TITLE
[~ENHANCEMENT] Secure Contact Form (Trusted Shops)

### DIFF
--- a/src/app/code/community/FireGento/GermanSetup/etc/config.xml
+++ b/src/app/code/community/FireGento/GermanSetup/etc/config.xml
@@ -25,11 +25,11 @@
             <germansetup>
                 <class>FireGento_GermanSetup_Model</class>
             </germansetup>
-			<tax>
-				<rewrite>
-					<config>FireGento_GermanSetup_Model_Tax_Config</config>
-				</rewrite>
-			</tax>
+            <tax>
+                <rewrite>
+                    <config>FireGento_GermanSetup_Model_Tax_Config</config>
+                </rewrite>
+            </tax>
         </models>
         <resources>
             <germansetup_setup>
@@ -77,6 +77,11 @@
                 </observers>
             </core_block_abstract_to_html_before>
         </events>
+        <frontend>
+            <secure_url>
+                <contacts>/contacts/</contacts>
+            </secure_url>
+        </frontend>
     </frontend>
     <adminhtml>
         <layout>


### PR DESCRIPTION
SSL Erzwingen beim Kontaktformular, u.a. auch Anforderung von Trusted Shops

habe auch mal [Tabs] \t in 4 Leerzeichen geändert, im Dokument war beides gemischt.
