### PR TITLE
Avoid getQuote() on the session if quote hasn't been initialized yet

### DIFF
--- a/src/app/code/community/FireGento/GermanSetup/Model/Tax/Config.php
+++ b/src/app/code/community/FireGento/GermanSetup/Model/Tax/Config.php
@@ -47,7 +47,16 @@ class FireGento_GermanSetup_Model_Tax_Config extends Mage_Tax_Model_Config
         /* @var $session Mage_Checkout_Model_Session */
         $session = Mage::getSingleton('checkout/session');
 
-        $quoteItems = $session->getQuote()->getAllItems();
+        if ($session->hasQuote()) {
+            $quoteItems = $session->getQuote()->getAllItems();
+        } else {
+            // This case happens if the store currency is switched by the customer.
+            // The quote isn't yet set on the session model at the time collectTotals()
+            // by the session because of the changed currency, which in turn ends up in this
+            // method, which again triggers collectTotals() by getting the quote from the
+            // session model, ending in a recursion loop.
+            $quoteItems = array();
+        }
         $taxClassIds = array();
         $highestTaxRate = null;
 


### PR DESCRIPTION
If the customer switches the store currency, `collectTotals()` is called on the quote model by the session before the quote is set on the session.
This means calls to `Mage::getSingleton('checkout/session')->getQuote()` will again instantiate and load a new quote model, on which will then try to collect the totals, resulting in an endless loop.

For this reason `Mage::getSingleton('checkout/session')->getQuote()` cannot be used by the tax/config model, unless the quote is already available on the checkout/session.

This fix works around the problem by simulating an empty quote items array, so the rewritten class will simply use the default shipping tax id.

Loading the quote item collection directly doesn't work without instantiating and loading the quote model manually, which would add a lot of overload.
Since the shipping totals are only displayed in the cart, where there is no currency switcher (by default), all should be good though.
If this solution isn't good enough, I would suggest creating a resource model that manually selects the tax classes from the quote item products, so that even though it's additional queries, they are minimized and optimized.
