### PR TITLE
MAGE 1.7.x - veränderte Mail-Variablen (Logo)

### DIFF
--- a/src/app/locale/de_DE/template/germansetup/email/account_new.html
+++ b/src/app/locale/de_DE/template/germansetup/email/account_new.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$customer.name":"Customer Name",
 "store url=\"customer/account/\"":"Customer Account Url",
 "var customer.email":"Customer Email",
@@ -20,7 +21,7 @@
 				<table cellspacing="0" cellpadding="0" border="0" width="650">
 					<tr>
 						<td valign="top">
-							<a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a>
+							<a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a>
 						</td>
 					</tr>
 				</table>

--- a/src/app/locale/de_DE/template/germansetup/email/account_new_confirmation.html
+++ b/src/app/locale/de_DE/template/germansetup/email/account_new_confirmation.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "store url=\"customer/account/\"":"Customer Account Url",
 "htmlescape var=$customer.name":"Customer Name",
 "var customer.email":"Customer Email",
@@ -20,7 +21,7 @@
 				<!-- [ header starts here] -->
 				<table cellspacing="0" cellpadding="0" border="0" width="650">
 					<tr>
-						<td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+						<td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
 					</tr>
 				</table>
 				<!-- [ middle starts here] -->

--- a/src/app/locale/de_DE/template/germansetup/email/account_new_confirmed.html
+++ b/src/app/locale/de_DE/template/germansetup/email/account_new_confirmed.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$customer.name":"Customer Name",
 "store url=\"customer/account/\"":"Customer Account Url"}
 @-->
@@ -17,7 +18,7 @@
 				<!-- [ header starts here] -->
 				<table cellspacing="0" cellpadding="0" border="0" width="650">
 					<tr>
-						<td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+						<td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></a></td>
 					</tr>
 				</table>
 				<!-- [ middle starts here] -->

--- a/src/app/locale/de_DE/template/germansetup/email/admin_password_new.html
+++ b/src/app/locale/de_DE/template/germansetup/email/admin_password_new.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$user.name":"Admin Name",
 "htmlescape var=$password":"Admin Password",
 "store url=\"adminhtml/index/resetpassword/\" _query_id=$user.id _query_token=$user.rp_token":"Admin Password Reset Url"
@@ -19,7 +20,7 @@
 				<table cellspacing="0" cellpadding="0" border="0" width="650">
 				<tr>
 				      <td valign="top">
-				         <p><a href="{{store url=""}}" style="color:#1E7EC8;"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" border="0"/></a></p>
+				         <p><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></p>
 				      </td>
 				 </tr>
 				 </table>

--- a/src/app/locale/de_DE/template/germansetup/email/creditmemo_new.html
+++ b/src/app/locale/de_DE/template/germansetup/email/creditmemo_new.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$order.getCustomerName()":"Customer Name",
 "var store.getFrontendName()":"Store Name",
 "store url=\"customer/account/\"":"Customer Account Url",
@@ -26,7 +27,7 @@
 	        <!-- [ header starts here] -->
 	        <table cellspacing="0" cellpadding="0" border="0" width="650">
 	            <tr>
-	                <td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+	                <td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
 	            </tr>
 	        </table>
 	        <!-- [ middle starts here] -->

--- a/src/app/locale/de_DE/template/germansetup/email/creditmemo_new_guest.html
+++ b/src/app/locale/de_DE/template/germansetup/email/creditmemo_new_guest.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$billing.getName()":"Guest Customer Name (Billing)",
 "var store.getFrontendName()":"Store Name",
 "var creditmemo.increment_id":"Credit Memo Id",
@@ -25,7 +26,7 @@
 	        <!-- [ header starts here] -->
 	        <table cellspacing="0" cellpadding="0" border="0" width="650">
 	            <tr>
-	                <td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+	                <td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
 	            </tr>
 	        </table>
 	        <!-- [ middle starts here] -->

--- a/src/app/locale/de_DE/template/germansetup/email/creditmemo_update.html
+++ b/src/app/locale/de_DE/template/germansetup/email/creditmemo_update.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$order.getCustomerName()":"Customer Name",
 "var order.increment_id":"Order Id",
 "var order.getStatusLabel()":"Order Status",
@@ -21,7 +22,7 @@
 	        <!-- [ header starts here] -->
 	        <table cellspacing="0" cellpadding="0" border="0" width="650">
 	        <tr>
-	            <td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+	            <td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
 	        </tr>
 	        </table>
 	

--- a/src/app/locale/de_DE/template/germansetup/email/creditmemo_update_guest.html
+++ b/src/app/locale/de_DE/template/germansetup/email/creditmemo_update_guest.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$billing.getName()":"Guest Customer Name",
 "var order.increment_id":"Order Id",
 "var order.getStatusLabel()":"Order Status",
@@ -20,7 +21,7 @@
 	        <!-- [ header starts here] -->
 	        <table cellspacing="0" cellpadding="0" border="0" width="650">
 	        <tr>
-	            <td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+	            <td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
 	        </tr>
 	        </table>
 	

--- a/src/app/locale/de_DE/template/germansetup/email/enterprise_invitation.html
+++ b/src/app/locale/de_DE/template/germansetup/email/enterprise_invitation.html
@@ -9,7 +9,8 @@
                 <table cellspacing="0" cellpadding="0" border="0" width="650">
                     <tr>
                         <td valign="top">
-                            <p><a href="{{store url=""}}" style="color:#1E7EC8;"><img src="{{skin url="images/logo_email.gif" _area='frontend'}}" alt="Magento" border="0"/></a></p></td>
+                            <p><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></p>
+						</td>
                     </tr>
                 </table>
 

--- a/src/app/locale/de_DE/template/germansetup/email/invoice_new.html
+++ b/src/app/locale/de_DE/template/germansetup/email/invoice_new.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$order.getCustomerName()":"Customer Name",
 "var store.getFrontendName()":"Store Name",
 "store url=\"customer/account/\"":"Customer Account Url",
@@ -30,7 +31,7 @@
 	        <!-- [ header starts here] -->
 	        <table cellspacing="0" cellpadding="0" border="0" width="650">
 	            <tr>
-	                <td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+	                <td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
 	            </tr>
 	        </table>
 	        <!-- [ middle starts here] -->

--- a/src/app/locale/de_DE/template/germansetup/email/invoice_new_guest.html
+++ b/src/app/locale/de_DE/template/germansetup/email/invoice_new_guest.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$billing.getName()":"Guest Customer Name",
 "var store.getFrontendName()":"Store Name",
 "var invoice.increment_id":"Invoice Id",
@@ -29,7 +30,7 @@
 	        <!-- [ header starts here] -->
 	        <table cellspacing="0" cellpadding="0" border="0" width="650">
 	            <tr>
-	                <td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+	                <td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
 	            </tr>
 	        </table>
 	        <!-- [ middle starts here] -->

--- a/src/app/locale/de_DE/template/germansetup/email/invoice_update.html
+++ b/src/app/locale/de_DE/template/germansetup/email/invoice_update.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$order.getCustomerName()":"Customer Name",
 "var order.increment_id":"Order Id",
 "var order.getStatusLabel()":"Order Status",
@@ -21,7 +22,7 @@
 	        <!-- [ header starts here] -->
 	        <table cellspacing="0" cellpadding="0" border="0" width="650">
 	        <tr>
-	            <td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+	            <td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
 	        </tr>
 	        </table>
 	

--- a/src/app/locale/de_DE/template/germansetup/email/invoice_update_guest.html
+++ b/src/app/locale/de_DE/template/germansetup/email/invoice_update_guest.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$billing.getName()":"Guest Customer Name",
 "var order.increment_id":"Order Id",
 "var order.getStatusLabel()":"Order Status",
@@ -20,7 +21,7 @@
 	        <!-- [ header starts here] -->
 	        <table cellspacing="0" cellpadding="0" border="0" width="650">
 	        <tr>
-	            <td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+	            <td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
 	        </tr>
 	        </table>
 	

--- a/src/app/locale/de_DE/template/germansetup/email/newsletter_subscr_confirm.html
+++ b/src/app/locale/de_DE/template/germansetup/email/newsletter_subscr_confirm.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$customer.name":"Customer Name",
 "var subscriber.getConfirmationLink()":"Subscriber Confirmation Url"}
 @-->
@@ -18,7 +19,7 @@
                 <table cellspacing="0" cellpadding="0" border="0" width="650">
                     <tr>
                         <td valign="top">
-                            <p><a href="{{store url=""}}" style="color:#1E7EC8;"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" border="0"/></a></p></td>
+                            <p><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></p></td>
                     </tr>
                 </table>
 

--- a/src/app/locale/de_DE/template/germansetup/email/order_new.html
+++ b/src/app/locale/de_DE/template/germansetup/email/order_new.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$order.getCustomerName()":"Customer Name",
 "var store.getFrontendName()":"Store Name",
 "store url=\"customer/account/\"":"Customer Account Url",
@@ -30,7 +31,7 @@
 				<!-- [ header starts here] -->
 				<table cellspacing="0" cellpadding="0" border="0" width="650">
 					<tr>
-						<td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+						<td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
 					</tr>
 				</table>
 				<!-- [ middle starts here] -->

--- a/src/app/locale/de_DE/template/germansetup/email/order_new_guest.html
+++ b/src/app/locale/de_DE/template/germansetup/email/order_new_guest.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$order.getBillingAddress().getName()":"Guest Customer Name",
 "var store.getFrontendName()":"Store Name",
 "var order.increment_id":"Order Id",
@@ -29,7 +30,7 @@
 				<!-- [ header starts here] -->
 				<table cellspacing="0" cellpadding="0" border="0" width="650">
 					<tr>
-						<td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+						<td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
 					</tr>
 				</table>
 				<!-- [ middle starts here] -->

--- a/src/app/locale/de_DE/template/germansetup/email/order_update.html
+++ b/src/app/locale/de_DE/template/germansetup/email/order_update.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$order.getCustomerName()":"Customer Name",
 "var order.increment_id":"Order Id",
 "var order.getStatusLabel()":"Order Status",
@@ -21,7 +22,7 @@
 	        <!-- [ header starts here] -->
 	        <table cellspacing="0" cellpadding="0" border="0" width="650">
 	        <tr>
-	            <td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+	            <td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
 	        </tr>
 	        </table>
 	

--- a/src/app/locale/de_DE/template/germansetup/email/order_update_guest.html
+++ b/src/app/locale/de_DE/template/germansetup/email/order_update_guest.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$billing.getName()":"Guest Customer Name",
 "var order.increment_id":"Order Id",
 "var order.getStatusLabel()":"Order Status",
@@ -20,7 +21,7 @@
         <!-- [ header starts here] -->
             <table cellspacing="0" cellpadding="0" border="0" width="650">
             <tr>
-                <td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+                <td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
             </tr>
             </table>
 

--- a/src/app/locale/de_DE/template/germansetup/email/password_new.html
+++ b/src/app/locale/de_DE/template/germansetup/email/password_new.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "store url=\"customer/account/\"":"Customer Account Url",
 "htmlescape var=$customer.name":"Customer Name",
 "store url=\"customer/account/resetpassword/\" _query_id=$customer.id _query_token=$customer.rp_token":"Password Reset Url"
@@ -19,7 +20,7 @@
 				<table cellspacing="0" cellpadding="0" border="0" width="650">
 					<tr>
 						<td valign="top">
-							<p><a href="{{store url=""}}" style="color:#1E7EC8;"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" border="0"/></a></p>
+							<p><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></p>
 						</td>
 					</tr>
 				</table>

--- a/src/app/locale/de_DE/template/germansetup/email/shipment_new.html
+++ b/src/app/locale/de_DE/template/germansetup/email/shipment_new.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$order.getCustomerName()":"Customer Name",
 "var store.getFrontendName()":"Store Name",
 "store url=\"customer/account/\"":"Customer Account Url",
@@ -31,7 +32,7 @@
 	        <!-- [ header starts here] -->
 	        <table cellspacing="0" cellpadding="0" border="0" width="650">
 	            <tr>
-	                <td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+	                <td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
 	            </tr>
 	        </table>
 	        <!-- [ middle starts here] -->

--- a/src/app/locale/de_DE/template/germansetup/email/shipment_new_guest.html
+++ b/src/app/locale/de_DE/template/germansetup/email/shipment_new_guest.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$billing.getName()":"Guest Customer Name",
 "var store.getFrontendName()":"Store Name",
 "var shipment.increment_id":"Shipment Id",
@@ -30,7 +31,7 @@
 	        <!-- [ header starts here] -->
 	        <table cellspacing="0" cellpadding="0" border="0" width="650">
 	            <tr>
-	                <td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+	                <td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
 	            </tr>
 	        </table>
 	        <!-- [ middle starts here] -->

--- a/src/app/locale/de_DE/template/germansetup/email/shipment_update.html
+++ b/src/app/locale/de_DE/template/germansetup/email/shipment_update.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$order.getCustomerName()":"Customer Name",
 "var order.increment_id":"Order Id",
 "var order.getStatusLabel()":"Order Status",
@@ -21,7 +22,7 @@
 	        <!-- [ header starts here] -->
 	        <table cellspacing="0" cellpadding="0" border="0" width="650">
 	        <tr>
-	            <td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+	            <td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
 	        </tr>
 	        </table>
 	

--- a/src/app/locale/de_DE/template/germansetup/email/shipment_update_guest.html
+++ b/src/app/locale/de_DE/template/germansetup/email/shipment_update_guest.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "htmlescape var=$billing.getName()":"Guest Customer Name",
 "var order.increment_id":"Order Id",
 "var order.getStatusLabel()":"Order Status",
@@ -20,7 +21,7 @@
 	        <!-- [ header starts here] -->
 	        <table cellspacing="0" cellpadding="0" border="0" width="650">
 	        <tr>
-	            <td valign="top"><a href="{{store url=""}}"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}"  style="margin-bottom:10px;" border="0"/></a></td>
+	            <td valign="top"><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></td>
 	        </tr>
 	        </table>
 	

--- a/src/app/locale/de_DE/template/germansetup/email/wishlist_share.html
+++ b/src/app/locale/de_DE/template/germansetup/email/wishlist_share.html
@@ -1,6 +1,7 @@
 <!--@vars
 {"store url=\"\"":"Store Url",
-"skin url=\"images/logo_email.gif\" _area='frontend'":"Email Logo Image",
+"var logo_url":"Email Logo Image Url",
+"var logo_alt":"Email Logo Image Alt",
 "var message":"Wishlist Message",
 "var items":"Wishlist Items"}
 @-->
@@ -17,7 +18,7 @@
             <table cellspacing="0" cellpadding="0" border="0" width="650">
             <tr>
                 <td valign="top">
-                    <p><a href="{{store url=""}}" style="color:#1E7EC8;"><img src="{{skin url="images/logo_email.gif" _area=''frontend''}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" border="0"/></a></p>
+                    <p><a href="{{store url=""}}"><img src="{{var logo_url}}" alt="{{block type="germansetup/imprint_field" value="shop_name"}}" style="margin-bottom:10px;" border="0"/></a></p>
                 </td>
             </tr>
             </table>


### PR DESCRIPTION
Die neuen unter Magento 1.7.x eingeführten Logovariablen wurden genau wie im aktuellen Preview vom Sprachpaket eingearbeitet, mit dem Unterschied das bei euch nach wie vor als Alt-Text nicht der globale Alttext sondern wie vorher auch der von euch angepasste verwendet wird.

Also: alt="{{block type="germansetup/imprint_field" value="shop_name"}}" 

Viel Spaß damit! :-)

Daniel
