### PR TITLE
Zeige "zzgl. Versandkosten" auch im Modus DISPLAY_TYPE_BOTH

### DIFF
--- a/src/app/design/frontend/base/default/template/germansetup/price_info.phtml
+++ b/src/app/design/frontend/base/default/template/germansetup/price_info.phtml
@@ -49,5 +49,9 @@
     	<span class="tax-details"><?php echo $this->__('Excl. %s Tax', $this->getFormattedTaxRate()) ?></span>
     <?php elseif ($this->getIsIncludingTax() == Mage_Tax_Model_Config::DISPLAY_TYPE_INCLUDING_TAX): ?>
     	<span class="tax-details"><?php echo $this->__('Incl. %s Tax', $this->getFormattedTaxRate()) ?></span>
+    <?php elseif ($this->getIsIncludingTax() == Mage_Tax_Model_Config::DISPLAY_TYPE_BOTH): ?>
+        <?php if (!$this->getIsIncludingShippingCosts()): ?>
+            <span class="tax-details"><?php echo $this->__('plus <a href="%s">Shipping Cost</a>', $shippingCostUrl) ?></span>
+        <?php endif ?>
     <?php endif ?>
 <?php endif ?>

--- a/src/app/locale/de_DE/FireGento_GermanSetup.csv
+++ b/src/app/locale/de_DE/FireGento_GermanSetup.csv
@@ -6,6 +6,7 @@
 "Incl. Tax, plus <a href=""%s"">Shipping Cost</a>","Inkl. MwSt., zzgl. <a href=""%s"">Versandkosten</a>"
 "Incl. %s Tax, plus <a href=""%s"">Shipping Cost</a>","Inkl. %s MwSt., zzgl. <a href=""%s"">Versandkosten</a>"
 "Excl. %s Tax, plus <a href=""%s"">Shipping Cost</a>","Zzgl. %s MwSt., zzgl. <a href=""%s"">Versandkosten</a>"
+"plus <a href=""%s"">Shipping Cost</a>","zzgl. <a href=""%s"">Versandkosten</a>"
 "Incl. Tax","Inkl. MwSt."
 "Incl. %s Tax","Inkl. %s MwSt."
 "Excl. %s Tax","Zzgl. %s MwSt."


### PR DESCRIPTION
Momenten wird die Info "zzgl. Versandkosten" nicht angezeigt, wenn man Brutto und Netto Preise gleichzeitig anzeigt.

Dieser PR würde das fixen - oder gibt es einen bestimmten Grund dafür?
