### PR TITLE
Newsletter Extension zur Liste hinzugefügt

### DIFF
--- a/src/app/design/adminhtml/default/default/template/germansetup/extensions.phtml
+++ b/src/app/design/adminhtml/default/default/template/germansetup/extensions.phtml
@@ -15,7 +15,7 @@
                     <tr><td class="value" colspan="2"><strong>Deutsches Sprachpaket</strong></td></tr>
                     <tr>
                         <td class="label"><label for="name">MagentoConnect</label></td>
-                        <td class="value"><a href="http://www.magentocommerce.com/extension/413/" target="_blank">http://www.magentocommerce.com/extension/413/</a></td>
+                        <td class="value"><a href="http://www.magentocommerce.com/magento-connect/catalog/product/view/id/2317/" target="_blank">http://www.magentocommerce.com/magento-connect/catalog/product/view/id/2317/</a></td>
                     </tr>
                     <tr>
                         <td class="label"><label for="name">Extension Key</label></td>
@@ -26,7 +26,7 @@
                     <tr><td class="value" colspan="2"><strong>NoState - Bundesland/Kanton entfernen</strong></td></tr>
                     <tr>
                         <td class="label"><label for="name">MagentoConnect</label></td>
-                        <td class="value"><a href="http://www.magentocommerce.com/extension/8047/" target="_blank">http://www.magentocommerce.com/extension/8047/</a></td>
+                        <td class="value"><a href="http://www.magentocommerce.com/magento-connect/catalog/product/view/id/9971/" target="_blank">http://www.magentocommerce.com/magento-connect/catalog/product/view/id/9971/</a></td>
                     </tr>
                     <tr>
                         <td class="label"><label for="name">Extension Key</label></td>
@@ -51,7 +51,7 @@
                     <tr><td class="value" colspan="2"><strong>Bankeinzug/Lastschrift</strong></td></tr>
                     <tr>
                         <td class="label"><label for="name">MagentoConnect</label></td>
-                        <td class="value"><a href="http://www.magentocommerce.com/extension/676/" target="_blank">http://www.magentocommerce.com/extension/676/</a></td>
+                        <td class="value"><a href="http://www.magentocommerce.com/magento-connect/catalog/product/view/id/2606/" target="_blank">http://www.magentocommerce.com/magento-connect/catalog/product/view/id/2606/</a></td>
                     </tr>
                     <tr>
                         <td class="label"><label for="name">Extension Key</label></td>
@@ -62,7 +62,7 @@
                     <tr><td class="value" colspan="2"><strong>Nachnahme</strong></td></tr>
                     <tr>
                         <td class="label"><label for="name">MagentoConnect</label></td>
-                        <td class="value"><a href="http://www.magentocommerce.com/extension/454/" target="_blank">http://www.magentocommerce.com/extension/454/</a></td>
+                        <td class="value"><a href="http://www.magentocommerce.com/magento-connect/catalog/product/view/id/2360/" target="_blank">http://www.magentocommerce.com/magento-connect/catalog/product/view/id/2360/</a></td>
                     </tr>
                     <tr>
                         <td class="label"><label for="name">Extension Key</label></td>
@@ -73,7 +73,7 @@
                     <tr><td class="value" colspan="2"><strong>Vorkasse</strong></td></tr>
                     <tr>
                         <td class="label"><label for="name">MagentoConnect</label></td>
-                        <td class="value"><a href="http://www.magentocommerce.com/extension/304/" target="_blank">http://www.magentocommerce.com/extension/304/</a></td>
+                        <td class="value"><a href="http://www.magentocommerce.com/magento-connect/catalog/product/view/id/2298/" target="_blank">http://www.magentocommerce.com/magento-connect/catalog/product/view/id/2298/</a></td>
                     </tr>
                     <tr>
                         <td class="label"><label for="name">Extension Key</label></td>

--- a/src/app/design/adminhtml/default/default/template/germansetup/extensions.phtml
+++ b/src/app/design/adminhtml/default/default/template/germansetup/extensions.phtml
@@ -33,6 +33,17 @@
                         <td class="value">http://connect20.magentocommerce.com/community/Dsdata_NoState</td>
                     </tr>
                     <tr><td colspan="2">&nbsp;</td></tr>
+
+                    <tr><td class="value" colspan="2"><strong>Newsletter Abmeldung als Gast und Double Opt-In für registrierte Kunden</strong></td></tr>
+                    <tr>
+                        <td class="label"><label for="name">MagentoConnect</label></td>
+                        <td class="value"><a href="http://www.magentocommerce.com/magento-connect/catalog/product/view/id/15534/" target="_blank">http://www.magentocommerce.com/magento-connect/catalog/product/view/id/15534/</a></td>
+                    </tr>
+                    <tr>
+                        <td class="label"><label for="name">Extension Key</label></td>
+                        <td class="value">http://connect20.magentocommerce.com/community/Loewenstark_Newsletter</td>
+                    </tr>
+                    <tr><td colspan="2">&nbsp;</td></tr>
                 </tbody>
             </table>
         </div>

--- a/src/app/design/adminhtml/default/default/template/germansetup/extensions.phtml
+++ b/src/app/design/adminhtml/default/default/template/germansetup/extensions.phtml
@@ -4,84 +4,84 @@
 </div>
 
 <div class="entry-edit">
-	<div class="entry-edit-head">
-    	<h4 class="icon-head head-edit-form fieldset-legend"><?php echo $this->__('Recommended Extensions') ?></h4>
+    <div class="entry-edit-head">
+        <h4 class="icon-head head-edit-form fieldset-legend"><?php echo $this->__('Recommended Extensions') ?></h4>
         <div class="form-buttons"></div>
     </div>
     <div class="fieldset fieldset-wide" id="group_fields7">
-		<div class="hor-scroll">
-    		<table cellspacing="0" class="form-list">
-        		<tbody>
-                	<tr><td class="value" colspan="2"><strong>Deutsches Sprachpaket</strong></td></tr>
+        <div class="hor-scroll">
+            <table cellspacing="0" class="form-list">
+                <tbody>
+                    <tr><td class="value" colspan="2"><strong>Deutsches Sprachpaket</strong></td></tr>
                     <tr>
-                    	<td class="label"><label for="name">MagentoConnect</label></td>
-                    	<td class="value"><a href="http://www.magentocommerce.com/extension/413/" target="_blank">http://www.magentocommerce.com/extension/413/</a></td>
+                        <td class="label"><label for="name">MagentoConnect</label></td>
+                        <td class="value"><a href="http://www.magentocommerce.com/extension/413/" target="_blank">http://www.magentocommerce.com/extension/413/</a></td>
                     </tr>
                     <tr>
-                    	<td class="label"><label for="name">Extension Key</label></td>
-                    	<td class="value">http://connect20.magentocommerce.com/community/Locale_Mage_community_de_DE</td>
+                        <td class="label"><label for="name">Extension Key</label></td>
+                        <td class="value">http://connect20.magentocommerce.com/community/Locale_Mage_community_de_DE</td>
                     </tr>
                     <tr><td colspan="2">&nbsp;</td></tr>
 
-                	<tr><td class="value" colspan="2"><strong>NoState - Bundesland/Kanton entfernen</strong></td></tr>
+                    <tr><td class="value" colspan="2"><strong>NoState - Bundesland/Kanton entfernen</strong></td></tr>
                     <tr>
-                    	<td class="label"><label for="name">MagentoConnect</label></td>
-                    	<td class="value"><a href="http://www.magentocommerce.com/extension/8047/" target="_blank">http://www.magentocommerce.com/extension/8047/</a></td>
+                        <td class="label"><label for="name">MagentoConnect</label></td>
+                        <td class="value"><a href="http://www.magentocommerce.com/extension/8047/" target="_blank">http://www.magentocommerce.com/extension/8047/</a></td>
                     </tr>
                     <tr>
-                    	<td class="label"><label for="name">Extension Key</label></td>
-                    	<td class="value">http://connect20.magentocommerce.com/community/Dsdata_NoState</td>
+                        <td class="label"><label for="name">Extension Key</label></td>
+                        <td class="value">http://connect20.magentocommerce.com/community/Dsdata_NoState</td>
                     </tr>
                     <tr><td colspan="2">&nbsp;</td></tr>
-				</tbody>
-    		</table>
-		</div>
-	</div>
+                </tbody>
+            </table>
+        </div>
+    </div>
 </div>
 
 <div class="entry-edit">
-	<div class="entry-edit-head">
-    	<h4 class="icon-head head-edit-form fieldset-legend"><?php echo $this->__('Popular Payment Methods in Germany') ?></h4>
+    <div class="entry-edit-head">
+        <h4 class="icon-head head-edit-form fieldset-legend"><?php echo $this->__('Popular Payment Methods in Germany') ?></h4>
         <div class="form-buttons"></div>
     </div>
     <div class="fieldset fieldset-wide" id="group_fields7">
-		<div class="hor-scroll">
-    		<table cellspacing="0" class="form-list">
-        		<tbody>
-                	<tr><td class="value" colspan="2"><strong>Bankeinzug/Lastschrift</strong></td></tr>
+        <div class="hor-scroll">
+            <table cellspacing="0" class="form-list">
+                <tbody>
+                    <tr><td class="value" colspan="2"><strong>Bankeinzug/Lastschrift</strong></td></tr>
                     <tr>
-                    	<td class="label"><label for="name">MagentoConnect</label></td>
-                    	<td class="value"><a href="http://www.magentocommerce.com/extension/676/" target="_blank">http://www.magentocommerce.com/extension/676/</a></td>
+                        <td class="label"><label for="name">MagentoConnect</label></td>
+                        <td class="value"><a href="http://www.magentocommerce.com/extension/676/" target="_blank">http://www.magentocommerce.com/extension/676/</a></td>
                     </tr>
                     <tr>
-                    	<td class="label"><label for="name">Extension Key</label></td>
-                    	<td class="value">http://connect20.magentocommerce.com/community/DebitPayment</td>
-                    </tr>
-                    <tr><td colspan="2">&nbsp;</td></tr>
-
-                	<tr><td class="value" colspan="2"><strong>Nachnahme</strong></td></tr>
-                    <tr>
-                    	<td class="label"><label for="name">MagentoConnect</label></td>
-                    	<td class="value"><a href="http://www.magentocommerce.com/extension/454/" target="_blank">http://www.magentocommerce.com/extension/454/</a></td>
-                    </tr>
-                    <tr>
-                    	<td class="label"><label for="name">Extension Key</label></td>
-                    	<td class="value">http://connect20.magentocommerce.com/community/CashOnDelivery</td>
+                        <td class="label"><label for="name">Extension Key</label></td>
+                        <td class="value">http://connect20.magentocommerce.com/community/DebitPayment</td>
                     </tr>
                     <tr><td colspan="2">&nbsp;</td></tr>
 
-                	<tr><td class="value" colspan="2"><strong>Vorkasse</strong></td></tr>
+                    <tr><td class="value" colspan="2"><strong>Nachnahme</strong></td></tr>
                     <tr>
-                    	<td class="label"><label for="name">MagentoConnect</label></td>
-                    	<td class="value"><a href="http://www.magentocommerce.com/extension/304/" target="_blank">http://www.magentocommerce.com/extension/304/</a></td>
+                        <td class="label"><label for="name">MagentoConnect</label></td>
+                        <td class="value"><a href="http://www.magentocommerce.com/extension/454/" target="_blank">http://www.magentocommerce.com/extension/454/</a></td>
                     </tr>
                     <tr>
-                    	<td class="label"><label for="name">Extension Key</label></td>
-                    	<td class="value">http://connect20.magentocommerce.com/community/BankPayment</td>
+                        <td class="label"><label for="name">Extension Key</label></td>
+                        <td class="value">http://connect20.magentocommerce.com/community/CashOnDelivery</td>
                     </tr>
                     <tr><td colspan="2">&nbsp;</td></tr>
-				</tbody>
-    		</table>
-		</div>
-	</div>
+
+                    <tr><td class="value" colspan="2"><strong>Vorkasse</strong></td></tr>
+                    <tr>
+                        <td class="label"><label for="name">MagentoConnect</label></td>
+                        <td class="value"><a href="http://www.magentocommerce.com/extension/304/" target="_blank">http://www.magentocommerce.com/extension/304/</a></td>
+                    </tr>
+                    <tr>
+                        <td class="label"><label for="name">Extension Key</label></td>
+                        <td class="value">http://connect20.magentocommerce.com/community/BankPayment</td>
+                    </tr>
+                    <tr><td colspan="2">&nbsp;</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
 </div>


### PR DESCRIPTION
- Tabs im Quellcode entfernt
- Neue Links gesetzt zu den Extensions, da bspw. Locale auf 404 geleitet hat
- Newsletter Extension zum Abmelden und Double-Opt-In für alle Ebenen.

Newsletter: http://www.magentocommerce.com/magento-connect/catalog/product/view/id/15534/
Github-Page:
https://github.com/mklooss/Loewenstark_Newsletter
