### PR TITLE
FIXED typo in sql-query

### DIFF
--- a/src/app/code/community/FireGento/GermanSetup/sql/germansetup_setup/mysql4-upgrade-1.1.3-1.1.4.php
+++ b/src/app/code/community/FireGento/GermanSetup/sql/germansetup_setup/mysql4-upgrade-1.1.3-1.1.4.php
@@ -46,7 +46,7 @@ if (version_compare(Mage::getVersion(), '1.6', '<')) {
           `status` int(11) NOT NULL DEFAULT '0' COMMENT 'Subscriber Status',
           `email` text COMMENT 'Subscriber Status',
           `created_at` timestamp NULL DEFAULT NULL COMMENT 'Changed at',
-          PRIMARY KEY (`id`),
+          PRIMARY KEY (`id`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Newsletter Subscriber Status Table';
     ");
 


### PR DESCRIPTION
Comma too much. Removed it, now it runs in magento <1.6 too.
