### PR TITLE
Fatal error in Agreements Block

### DIFF
--- a/src/app/code/community/FireGento/GermanSetup/Block/Checkout/Agreements.php
+++ b/src/app/code/community/FireGento/GermanSetup/Block/Checkout/Agreements.php
@@ -43,6 +43,11 @@ class FireGento_GermanSetup_Block_Checkout_Agreements extends Mage_Checkout_Bloc
     public function getAgreements()
     {
         $agreements = parent::getAgreements();
+
+		if (!is_object($agreements) || method_exists($agreements, 'addFieldToFilter')) {
+			return $agreements;
+		}
+
         if ($this->_getCustomerSession()->isLoggedIn()) {
             $agreements->addFieldToFilter('agreement_type', array('in' => array(
                 FireGento_GermanSetup_Model_Source_AgreementType::AGREEMENT_TYPE_CHECKOUT,


### PR DESCRIPTION
I received the following fatal error and figured, this happens, when the agreements have not yet been set up in the project's configuration. In this case, the parent block returns an empty array, which can be handled by the frontend template but not by the GermanSetup's block code.

Fatal error: Call to a member function addFieldToFilter() on a non-object in /var/www/.../app/code/community/FireGento/GermanSetup/Block/Checkout/Agreements.php on line 52
