### PR TITLE
Update delivery_time.phtml

### DIFF
--- a/src/app/design/frontend/base/default/template/germansetup/delivery_time.phtml
+++ b/src/app/design/frontend/base/default/template/germansetup/delivery_time.phtml
@@ -39,6 +39,6 @@
 
 <?php if ($this->getProduct()->getDeliveryTime()): ?>
 <p class="delivery-time">
-    <?php echo $this->__('Delivery Time') ?>: <?php echo $this->getProduct()->getDeliveryTime() ?>
+    <?php echo $this->__('Delivery Time') ?>: <?php echo $this->getProduct()->getAttributeText('delivery_time') ?>
 </p>
 <?php endif ?>


### PR DESCRIPTION
Wenn man die Lieferzeit manuell in Dropdown ändert, wird sonst die ID des Feldes, statt dessen Inhalt angezeigt.
