### PR TITLE
Fix translation module reference

### DIFF
--- a/src/app/code/community/FireGento/GermanSetup/Helper/Checkout/Data.php
+++ b/src/app/code/community/FireGento/GermanSetup/Helper/Checkout/Data.php
@@ -34,6 +34,15 @@
 class FireGento_GermanSetup_Helper_Checkout_Data
     extends Mage_Checkout_Helper_Data
 {
+
+    /**
+     * Avoid loss of translation
+     */
+    function __construct()
+    {
+        $this->_moduleName = 'Mage_Checkout';
+    }
+
     /**
      * get all Required Agreement Ids
      *


### PR DESCRIPTION
Angenommen man nutzt GermanSetup und den German Locale Pack. Developer Mode an.

Nun sind bei den Checkout Schritten einige in English (Lieferadresse, Versandart, Bestellübersicht).

Dieser PR fixt das.
