### PR TITLE
#200: Prevent warning during auto meta generation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -1,3 +1,12 @@
+Umzug / Deprecated
+==================
+
+Diese Extension wird nicht mehr weiterentickelt und sollte daher nicht mehr verwendet werden. Bitte verwenden Sie stattdessen 
+die offizielle Weiterentwicklung dieses Projekts: [FireGento_MageSetup](https://github.com/firegento/firegento-magesetup).
+
+Wenn Sie von FireGento_GermanSetup zu FireGento_MageSetup wechseln möchten, löschen Sie einfach die Dateien von FireGento_GermanSetup
+und installieren Sie die Neuen von FireGento_MageSetup. Sofern Sie Composer verwenden, genügt ein Austausch in Ihrer composer.json - Datei.
+
 FireGento_GermanSetup
 =====================
 German Setup konfiguriert einen Shop für den deutschen Markt.

--- a/src/app/code/community/FireGento/GermanSetup/Model/Observer.php
+++ b/src/app/code/community/FireGento/GermanSetup/Model/Observer.php
@@ -152,11 +152,18 @@ class FireGento_GermanSetup_Model_Observer
      * Get the categories of the current product
      *
      * @param  Mage_Catalog_Model_Product $product Product
-     * @return array                      Categories
+     * @return string                              Keywords
      */
     protected function _getCategoryKeywords($product)
     {
         $categories = $product->getCategoryIds();
+
+        //Check for empty categories
+        if (true === empty($categories)) {
+            return array();
+        }
+
+        //If product categories were given fetch their names and build the keyword string
         $categoryArr = $this->_fetchCategoryNames($categories);
         $keywords = $this->_buildKeywords($categoryArr);
 
@@ -221,6 +228,12 @@ class FireGento_GermanSetup_Model_Observer
     protected function _buildKeywords($categoryTypes)
     {
         $keywords = '';
+
+        //Check for empty category types
+        if (true === empty($categoryTypes)) {
+            return $keywords;
+        }
+
         foreach ($categoryTypes as $categories) {
             $keywords .= implode(', ', $categories);
         }


### PR DESCRIPTION
Fix for issue #200

Check for check for empty categories and categoryTypes in observer to prevent warning during auto meta generation
